### PR TITLE
Automatically prepend the port onto the APP_URL

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -16,7 +16,7 @@ return [
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
-        env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) : ''
+        env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) . (parse_url(env('APP_URL'), PHP_URL_PORT) ? ':' . parse_url(env('APP_URL'), PHP_URL_PORT) : '') : ''
     ))),
 
     /*


### PR DESCRIPTION
Not including the local port is a [common issue](https://stackoverflow.com/questions/61421547/getting-401-unauthorized-for-laravel-sanctum) when setting up Sanctum auth for new users.

There's already config code to fallback to the APP_URL if the SANCTUM_STATEFUL_DOMAINS env var isn't present - this just sures up that fallback code to also include the port if its preset and ignores it if not.